### PR TITLE
Put current conference in url

### DIFF
--- a/app/controllers/management/call_for_participations_controller.rb
+++ b/app/controllers/management/call_for_participations_controller.rb
@@ -1,21 +1,13 @@
 module Management
   class CallForParticipationsController < ManagementController
-    before_action :assign_conference
-
     def create
-      @conference.call_for_participation.open!
+      current_conference.call_for_participation.open!
       render :redraw
     end
 
     def destroy
-      @conference.call_for_participation.close!
+      current_conference.call_for_participation.close!
       render :redraw
-    end
-
-    private
-
-    def assign_conference
-      @conference = Conference.find params[:conference_id]
     end
   end
 end

--- a/app/controllers/management/conferences_controller.rb
+++ b/app/controllers/management/conferences_controller.rb
@@ -10,8 +10,7 @@ module Management
       @conference = Conference.new(conference_params)
 
       if @conference.save
-        set_current_conference(@conference)
-        redirect_to [:management, @conference]
+        redirect_to management_conference_path(@conference, current_conference: @conference.slug)
       else
         render :new
       end
@@ -39,9 +38,8 @@ module Management
     def destroy
       @conference = find_conference
       @conference.destroy
-      set_current_conference(nil)
 
-      redirect_to management_root_path
+      redirect_to management_root_path(current_conference: nil)
     end
 
     private

--- a/app/controllers/management/home_controller.rb
+++ b/app/controllers/management/home_controller.rb
@@ -5,9 +5,7 @@ module Management
 
     def set_conference
       conference = Conference.find(params[:id])
-      set_current_conference(conference)
-
-      redirect_to [:management, conference]
+      redirect_to management_conference_path(conference, current_conference: conference.slug)
     end
   end
 end

--- a/app/controllers/management/management_controller.rb
+++ b/app/controllers/management/management_controller.rb
@@ -7,7 +7,7 @@ module Management
     private
 
     def default_url_options(options = {})
-      { current_conference: current_conference.slug }.merge(options)
+      { current_conference: current_conference.try(:slug) }.merge(options)
     end
 
     def current_conference?

--- a/app/controllers/management/management_controller.rb
+++ b/app/controllers/management/management_controller.rb
@@ -15,28 +15,15 @@ module Management
     end
     helper_method :current_conference?
 
-    # TODO (2015-06-09) Fetch conferences by slug only
     def current_conference
       @current_conference ||=
         begin
-          # if params[:current_conference]
-          #   Conference.find_by_slug(params[:current_conference])
-          # end
-
-          if session[:current_conference_id]
-            Conference.find_by(id: session[:current_conference_id])
+          if params[:current_conference]
+            Conference.find_by_slug(params[:current_conference])
           end
         end
     end
     helper_method :current_conference
-
-    def set_current_conference(conference)
-      if conference.present?
-        session[:current_conference_id] = conference.id
-      else
-        session.delete(:current_conference_id)
-      end
-    end
 
     def authorize_user!
       head :forbidden unless current_user.admin?

--- a/app/controllers/management/management_controller.rb
+++ b/app/controllers/management/management_controller.rb
@@ -6,13 +6,27 @@ module Management
 
     private
 
+    def default_url_options(options = {})
+      { current_conference: current_conference.slug }.merge(options)
+    end
+
     def current_conference?
       current_conference.present?
     end
     helper_method :current_conference?
 
+    # TODO (2015-06-09) Fetch conferences by slug only
     def current_conference
-      @current_conference ||= (session[:current_conference_id] and Conference.find_by(id: session[:current_conference_id]))
+      @current_conference ||=
+        begin
+          # if params[:current_conference]
+          #   Conference.find_by_slug(params[:current_conference])
+          # end
+
+          if session[:current_conference_id]
+            Conference.find_by(id: session[:current_conference_id])
+          end
+        end
     end
     helper_method :current_conference
 

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -28,6 +28,16 @@ class Conference < ActiveRecord::Base
     submissions.group_by { |s| s.confirmed_at.to_date }
   end
 
+  def slug
+    title.gsub(' ', '-')
+  end
+
+  # TODO (2015-06-09) Stupid and temporary, put slug in db
+  # TODO (2015-06-09) Also, doesn't work due to translations?
+  # def self.find_by_slug(slug)
+  #   find_by(title: slug.to_s.gsub('-', ' '))
+  # end
+
   private
 
   def start_date_is_before_end_date

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -16,6 +16,7 @@ class Conference < ActiveRecord::Base
 
   accepts_nested_attributes_for :tracks, :halls, reject_if: :all_blank, allow_destroy: true
 
+  before_create :slugify_title
   after_create :create_call_for_participation
 
   def submissions_grouped_by_day
@@ -28,15 +29,13 @@ class Conference < ActiveRecord::Base
     submissions.group_by { |s| s.confirmed_at.to_date }
   end
 
-  def slug
-    title.gsub(' ', '-')
+  def self.find_by_slug(slug)
+    find_by(slug: slug)
   end
 
-  # TODO (2015-06-09) Stupid and temporary, put slug in db
-  # TODO (2015-06-09) Also, doesn't work due to translations?
-  # def self.find_by_slug(slug)
-  #   find_by(title: slug.to_s.gsub('-', ' '))
-  # end
+  def slugify_title
+    self.slug = title.gsub(/\s+/, '-')
+  end
 
   private
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,14 +7,17 @@ Rails.application.routes.draw do
     put '/set_conference/:id', to: 'home#set_conference', as: :set_conference
 
     resources :conferences
-    resources :events
-    resources :volunteers
-    resources :sponsorship_offers
-    resource :call_for_participation, only: [:create, :destroy]
 
-    resources :users do
-      member do
-        put :toggle_admin
+    scope ':current_conference' do
+      resources :events
+      resources :volunteers
+      resources :sponsorship_offers
+      resource :call_for_participation, only: [:create, :destroy]
+
+      resources :users do
+        member do
+          put :toggle_admin
+        end
       end
     end
   end

--- a/db/migrate/20150530182857_populate_conference_id_in_personal_profiles.rb
+++ b/db/migrate/20150530182857_populate_conference_id_in_personal_profiles.rb
@@ -6,7 +6,10 @@ end
 
 class PopulateConferenceIdInPersonalProfiles < ActiveRecord::Migration
   def change
-    conference = Conference.first!
-    PersonalProfile.where(conference_id: nil).update_all(conference_id: conference.id)
+    conference = Conference.first
+
+    if conference
+      PersonalProfile.where(conference_id: nil).update_all(conference_id: conference.id)
+    end
   end
 end

--- a/db/migrate/20150712103000_add_slug_to_conferences.rb
+++ b/db/migrate/20150712103000_add_slug_to_conferences.rb
@@ -1,0 +1,6 @@
+class AddSlugToConferences < ActiveRecord::Migration
+  def change
+    add_column :conferences, :slug, :string
+    add_index :conferences, :slug
+  end
+end

--- a/db/migrate/20150712103031_create_slugs_for_existing_conferences.rb
+++ b/db/migrate/20150712103031_create_slugs_for_existing_conferences.rb
@@ -1,0 +1,13 @@
+class CreateSlugsForExistingConferences < ActiveRecord::Migration
+  class Conference < ActiveRecord::Base
+  end
+
+  def change
+    Globalize.with_locale(:en) do
+      Conference.find_each do |c|
+        c.slug = c.title.gsub(/\s+/, '-')
+        c.save!
+      end
+    end
+  end
+end

--- a/spec/controllers/management/call_for_participations_controller_spec.rb
+++ b/spec/controllers/management/call_for_participations_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Management::CallForParticipationsController, type: :controller do
   describe 'POST #create' do
     it 'opens the CFP of the specified conference' do
       expect do
-        post 'create', conference_id: conference.id, format: :js
+        post 'create', current_conference: conference.slug, format: :js
       end.to change { Conference.find(conference.id).call_for_participation.in_progress? }.from(false).to(true)
     end
   end
@@ -18,7 +18,7 @@ RSpec.describe Management::CallForParticipationsController, type: :controller do
       conference.call_for_participation.open!
 
       expect do
-        delete 'destroy', conference_id: conference.id, format: :js
+        delete 'destroy', current_conference: conference.slug, format: :js
       end.to change { Conference.find(conference.id).call_for_participation.in_progress? }.from(true).to(false)
     end
   end

--- a/spec/factories/conferences.rb
+++ b/spec/factories/conferences.rb
@@ -2,7 +2,7 @@
 
 FactoryGirl.define do
   factory :conference do
-    title { |n| "Conference-#{n}" }
+    sequence(:title) { |n| "Conference-#{n}" }
     email
     description 'MyText'
     start_date '2014-07-29 21:29:13'


### PR DESCRIPTION
Идеята е да имаме url-и като `/management/OpenFest-2015/events`. Параметъра за scope ще се set-ва с `default_url_params`, и така няма да трябва да го предаваме навсякъде.

Един недостатък е, че url-ите, които не са scope-нати под ":current_conference" ще им се добави отзад `?current_conference=OpenFest-2015`, което ще изглежда малко странно. Не бих казал, че е голям проблем.

Следващата стъпка (ако решим да правим това) ще е да се сложи slug поле в базата, което може да се генерира от английския превод на title-а, макар че може би ще е добре да го оставим editable поле. Може и да ползваме нещо като `conference-#{id}`, ако само и единствено ни пука за linkability и не толкова за това колко смислени изглеждат url-ите, ама ако ще са linkable, поне нека да са адекватно четими.