### PR TITLE
Scope event operations to the current conference

### DIFF
--- a/app/controllers/management/events_controller.rb
+++ b/app/controllers/management/events_controller.rb
@@ -2,23 +2,22 @@ module Management
   class EventsController < ManagementController
     def index
       @conference = find_conference
-      # TODO (2015-07-14) Scoped by conference? Why no conference_id
-      @events = Event.approved
+      @events = @conference.events.approved
     end
 
     def show
       @conference = find_conference
-      @event = Event.find(params[:id])
+      @event = @conference.events.find(params[:id])
     end
 
     def edit
       @conference = find_conference
-      @event = Event.find(params[:id])
+      @event = @conference.events.find(params[:id])
     end
 
     def update
       @conference = find_conference
-      @event = Event.find(params[:id])
+      @event = @conference.events.find(params[:id])
 
       if @event.update_attributes(event_params)
         flash[:notice] = 'Event was successfully updated.'
@@ -30,7 +29,7 @@ module Management
 
     def destroy
       @conference = find_conference
-      @event = Event.find(params[:id])
+      @event = @conference.events.find(params[:id])
       @event.destroy
 
       redirect_to action: :index

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,9 @@
 class Event < ActiveRecord::Base
   include Proposable
 
+  has_one :track, through: :proposition, source: :proposition_accepting, source_type: Track
+  has_one :conference, through: :track
+
   validates :title, presence: true
   validates :length, presence: true, numericality: {only_integer: true, greater_than: 0}
   validates :abstract, presence: true


### PR DESCRIPTION
An indirect Conference -> Track -> Proposition -> Event relation exists
within the data model. Use it to limit all operations in the Events
controller to events, associated with the current conference.