### PR TITLE
Optimise the Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 language: ruby
 cache: bundler
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.2
   - 2.2.2
+  - 2.1.6
+  - 2.0.0
+  - 1.9.3
+matrix:
+  allow_failures:
+    - rvm: 1.9.3
+    - rvm: 2.0.0
+  fast_finish: true
 script:
   - RAILS_ENV=test bundle exec rake --trace bootstrap spec
 sudo: false


### PR DESCRIPTION
Make sure Travis starts its build from the newest Ruby version and allow
failures on older Ruby versions. Also specify the fast_finish directive
that instructs Travis to mark the build as successful/failed when all
builds with Rubies that are not allowed to fail are complete.